### PR TITLE
Fix loader & add cluster files

### DIFF
--- a/cluster/loader-tpl.yaml
+++ b/cluster/loader-tpl.yaml
@@ -34,6 +34,9 @@ spec:
         - name: users
           mountPath: "/data/users"
           readOnly: true
+        - name: playlist
+          mountPath: "/data/playlist"
+          readOnly: true
       volumes:
       - name: music
         configMap:
@@ -41,5 +44,8 @@ spec:
       - name: users
         configMap:
           name: users
+      - name: playlist
+        configMap:
+          name: playlist
       restartPolicy: Never
   backoffLimit: 0

--- a/cluster/playlist-header.yaml
+++ b/cluster/playlist-header.yaml
@@ -1,0 +1,7 @@
+# Header for ConfigMap built from playlist.csv
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: playlist
+data:
+  playlist.csv: |

--- a/gatling/resources/music.csv
+++ b/gatling/resources/music.csv
@@ -5,3 +5,4 @@ Sini Sabotage,Mun Planeeta,22e47f97-11ca-4c3c-8e77-f3068fddaf6e
 William Prince,Reliever,26e6462c-eacf-40bb-b4d0-d683966e2624
 Gang of Four,Isle of Dogs,bb9e9105-6224-4a60-aabd-8d29cc4b1349
 Carla Bley Trio,Utviklingssang,0894ddc7-0c84-4f13-a037-ddcaa1134ec8
+lolololol,lolololol,0894ddc7-0c84-4f13-a037-ddcaa1134ec7

--- a/loader/app.py
+++ b/loader/app.py
@@ -129,7 +129,7 @@ if __name__ == '__main__':
         rdr = csv.reader(inp)
         next(rdr)  # Skip header
         for name, songs, uuid in rdr:
-            resp = create_song(name.strip(),
+            resp = create_playlist(name.strip(),
                                eval(songs.strip()),
                                uuid.strip())
             resp = check_resp(resp, 'playlist_id')

--- a/loader/requirements.txt
+++ b/loader/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.24.0
-urllib3==1.26.5
+requests==2.27.1
+urllib3==1.26.9


### PR DESCRIPTION
# Fix loader & add cluster files

- Fixed loader so that we can run `make -f k8s.mak loader`
- Added cluster files for config map for playlist service
- Fixed playlist loader running the `create_song` function
- Updated dependency file for loader which caused build errors

## Testing

```sh
make -f eks.mak loader
```

and correctly inserts rows into the playlist DDB table

# ⚠ Action items for existing operators

Since there was an update to one of the template files, operators will need to run:
```sh
make -f k8s-tpl.mak templates
```