### PR TITLE
Add s3 to grafana dashboard

### DIFF
--- a/cluster/grafana-flask-configmap.yaml
+++ b/cluster/grafana-flask-configmap.yaml
@@ -613,6 +613,12 @@ data:
               "interval": "",
               "legendFormat": "cmpt756s2",
               "refId": "C"
+            },
+            {
+              "expr": "sum(rate(flask_http_request_duration_seconds_sum{status=\"200\",service=\"cmpt756s3\"}[1m]))\n/\nsum(rate(flask_http_request_duration_seconds_count{status=\"200\",service=\"cmpt756s3\"}[1m]))",
+              "interval": "",
+              "legendFormat": "cmpt756s3",
+              "refId": "D"
             }
           ],
           "thresholds": [],
@@ -724,13 +730,19 @@ data:
               "expr": "histogram_quantile(0.5, sum by (le) (rate(flask_http_request_duration_seconds_bucket{service=\"cmpt756s1\",status=\"200\"}[1m])))",
               "interval": "",
               "legendFormat": "cmpt756s1",
-              "refId": "C"
+              "refId": "B"
             },
             {
               "expr": "histogram_quantile(0.5, sum by (le) (rate(flask_http_request_duration_seconds_bucket{service=\"cmpt756s2\",status=\"200\"}[1m])))",
               "interval": "",
               "legendFormat": "cmpt756s2",
-              "refId": "B"
+              "refId": "C"
+            },
+            {
+              "expr": "histogram_quantile(0.5, sum by (le) (rate(flask_http_request_duration_seconds_bucket{service=\"cmpt756s3\",status=\"200\"}[1m])))",
+              "interval": "",
+              "legendFormat": "cmpt756s3",
+              "refId": "D"
             }
           ],
           "thresholds": [],
@@ -1053,6 +1065,12 @@ data:
               "interval": "",
               "legendFormat": "cmpt756s2",
               "refId": "C"
+            },
+            {
+              "expr": "histogram_quantile(0.9, sum by (le) (rate(flask_http_request_duration_seconds_bucket{service=\"cmpt756s3\",status=\"200\"}[1m])))",
+              "interval": "",
+              "legendFormat": "cmpt756s3",
+              "refId": "D"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
# Add service 3 to grafana dashboard

![image](https://user-images.githubusercontent.com/9442294/161458131-f084de58-cd77-4a4b-9e67-5281bcc33392.png)

## ⚠Action steps for existing operators

You need to re-deploy grafana and prometheus. Do so by running:

```sh
make -f obs.mak uninstall-prom
make -f obs.mak install-prom
```